### PR TITLE
fix: backend mongo db client initialization now uses DB_NAME env var

### DIFF
--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -13,6 +13,9 @@ from app.models.games import Game
 load_dotenv()
 
 async def init_db():
+    # Initialize the MongoDB client and Beanie ODM
+    # Connect using env vars MONGO_URI and DB_NAME, with defaults if not set
     client = AsyncMongoClient(os.getenv("MONGO_URI", "mongodb://localhost:27017/"))
+    db_name = os.getenv("DB_NAME", "appdb")
 
-    await init_beanie(database=client.db_name, document_models=[Player, Team, Game])
+    await init_beanie(database=client[db_name], document_models=[Player, Team, Game])


### PR DESCRIPTION
Fixes #23 